### PR TITLE
Fix for missing Python dependency 'PySocks' and suggestion for more transparent event handling.

### DIFF
--- a/onionsearch/core.py
+++ b/onionsearch/core.py
@@ -893,8 +893,8 @@ def run_method(method_name_and_argument):
     ret = []
     try:
         ret = globals()[method_name](argument)
-    except:
-        print("Error: unable to connect")
+    except Exception as e:
+        print(f'Exception occured: {e}')
     return ret
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version="1",
     packages=find_packages(),
     author="megadose",
-    install_requires=["requests","argparse","termcolor","tqdm", "html5lib","bs4"],
+    install_requires=["requests","argparse","termcolor","tqdm", "html5lib","bs4","PySocks"],
     description="OnionSearch is a script that scrapes urls on different .onion search engines.",
     include_package_data=True,
     url='http://github.com/megadose/OnionSearch',


### PR DESCRIPTION
Hello,

Today I did two installations of your script on two fresh boxes (Debian 10, Ubuntu 20.10), both of them ended up giving the same error on startup:
```
###@###:/opt/OnionSearch # onionsearch "computer"
search.py started with 3 processing units...
Error: unable to connect1):   0%|                                                                                  | 0/1 [00:00<?, ?it/s]
Error: unable to connect
Error: unable to connect
Error: unable to connect
```

At the first glance it seemed like a networking error, based on the wording of an error itself.
After digging into the code, I've realized that it's rather a hardcoded output in exception handling.
Simply changing the:
```python
except:
    print("Error: unable to connect")
```
To:
```python
except Exception as e:
    print(e)
```
gave me a much reasonable output for debug purposes:
```
###@###:~/OnionSearch# python3 search.py --mp_units 1 "test"
search.py started with 1 processing units...
Ahmia (#0):   0%|                                                                                                                                      | 0/1 [00:00<?, ?it/s]
Missing dependencies for SOCKS support.
Missing dependencies for SOCKS support.
```

Simple installation of PySocks: ```pip3 install PySocks``` has successfully corrected the error.
Therefore, this pull request corrects the missing dependency and, in my opinion, simplifies understanding of the errors by displaying an actual exception.

Hope you'll find this correction legitimate.
Best wishes and thank you for the great tool!